### PR TITLE
Fix Heroku deploy button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem 'refinerycms-wymeditor', git: 'https://github.com/parndt/refinerycms-wymedit
 
 # The default authentication adapter
 gem 'refinerycms-authentication-devise', git: 'https://github.com/refinery/refinerycms-authentication-devise', branch: 'master'
+
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
+GIT
   remote: https://github.com/parndt/refinerycms-wymeditor
   revision: 18571cd34ef30f7fba397c0623248eb25191abb7
   branch: master
@@ -206,7 +213,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
@@ -352,6 +358,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mimemagic!
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)
   rails (~> 6.0.2)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Refinery Example App
 
+## Deploy to Heroku
+
   [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/refinery/refinery-example-app)
+
+## Installation on localhost
+
+If you start the project on localhost, the `error Couldn't find an integrity file` will be raised. Fix it by `yarn install --check-files`
+
+If the another error `app_name@0.1.0: The engine "node" is incompatible with this module. Expected version "12.13.0". Got "XX.YY.ZZ"` is raised, it is because you dont have exact version
+of node - v12.13.0 installed. Ignore this error by running command `yarn install --ignore-engines` 

--- a/app.json
+++ b/app.json
@@ -11,6 +11,14 @@
       "cms",
       "ruby"
     ],
+    "buildpacks": [
+      {
+        "url": "heroku/nodejs"
+      },
+      {
+        "url": "heroku/ruby"
+      }
+    ],
     "addons": [
       "heroku-postgresql:hobby-dev"
     ],
@@ -31,5 +39,6 @@
       "SECRET_KEY_BASE": {
         "generator": "secret"
       }
-    }
+    },
+    "stack": "heroku-18"
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "@rails/webpacker": "4.2.2",
     "turbolinks": "^5.2.0"
   },
+  "engines": {
+    "node": "12.13.0"
+  },
   "version": "0.1.0",
   "devDependencies": {
     "webpack-dev-server": "^3.9.0"


### PR DESCRIPTION
Hi @parndt 

I have fixed the Heroku deploy button. This fixes open issues at https://github.com/refinery/refinerycms-example-app/issues/29 and https://github.com/refinery/refinerycms/issues/3508

1)
The first problem was, that ruby-2.6.5 is no longer available on heroku-20 and heroku-22 Heroku stacks. So I have set the default stack to "heroku-18" Note from heroku deploy proces:

This app is using the Heroku-18 stack, which is deprecated:
https://devcenter.heroku.com/changelog-items/2432
From April 30th 2023, Heroku-18 will be end-of-life, and apps using it
will no longer receive security updates, and be run at your own risk.
From May 1st 2023, builds will no longer be allowed for Heroku-18 apps.

2) 
The second issue was, that on 16 December 2021, Heroku changed the Node version to 16.13.1 (which was previously 12.16.2). 
To fix this, I inserted 'buildpacks' section to `app.json` configuration and exact version of Node to package.json. Now the Node v12.13.0 is installed and is installed before installation of Ruby gems.

This fixes the Heroku deployment

3)
Because I have added the "node": "12.13.0" to the package.json file, it raises error on localhost installations. The error is `error app_name@0.1.0: The engine "node" is incompatible with this module. Expected version "12.13.0". Got "10.19.0"` The `10.19.0` number is the version of Node you have installed on localhost. To ignore this warning and run the Node you have installed, simly ignore it with `yarn install --ignore-engines` I have added the info to the Readme.   

Thanks,
Martin